### PR TITLE
refactor bootstrap,git,zsh roles to work with OSX 10.14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's designed to init new dotfiles as needed, so be aware that it may clobber ex
 ## Usage
 
 ### Prerequisites
-1. Python 2.7+ and `pip`
+1. Python 2.7+ and `pip` (sudo easy_install pip)
 2. A user account that's a member of the sudoers group `adduser <user> sudo`
 3. Ansible `sudo pip install ansible`
 4. An internet connection

--- a/main.yml
+++ b/main.yml
@@ -64,35 +64,6 @@
   tags:
     - docker
 
-- name: Install dropbox
-  hosts: all
-  roles:
-  - dropbox
-  tags:
-  - dropbox
-
-- name: Install slack
-  hosts: all
-  roles:
-    - slack
-  tags:
-    - slack
-
-- name: Prepare for music
-  hosts: all
-  roles:
-    - audio
-  tags:
-    - audio
-
-#- name: Prepare to read
-#  hosts: all
-#  roles:
-#     - read
-#  tags:
-#    - read
-#  become: true
-
 - name: Install misc packages
   hosts: all
   roles:

--- a/roles/aws/tasks/main.yml
+++ b/roles/aws/tasks/main.yml
@@ -14,5 +14,5 @@
 - name: reload zshrc
   shell: "source ~/.zshrc"
   args:
-    executable: /usr/local/bin/zsh
+    executable: /bin/zsh
   when: ansible_system == "Darwin"

--- a/roles/bootstrap/tasks/darwin.yml
+++ b/roles/bootstrap/tasks/darwin.yml
@@ -1,4 +1,40 @@
----
+- name: touch installondemand file
+  file:
+    state: touch
+    path: /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+
+- name: Install Xcode Command Line Tools
+  shell: |
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    softwareupdate -i "$PROD"
+
+- name: remove installondemand file
+  file:
+    state: absent
+    path: /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+
+- name: alias xcrun git to git in profile
+  copy:
+    dest: "/Users/{{ ansible_user_id }}/.profile"
+    content: aliast git='xcrun git'
+
+- name: ensure homebrew dir exists
+  file:
+    path: /usr/local/homebrew
+    state: directory
+    mode: 0755
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+  become: yes
+
+- name: install homebrew
+  shell: cd /usr/local/src && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C /usr/local/homebrew
+
+- name: add homebrew binaries to path
+  copy:
+    dest: "/Users/{{ ansible_user_id }}/.profile"
+    content: PATH=$PATH:/usr/local/homebrew/bin
+
 - name: update homebrew
   homebrew:
     update_homebrew: yes

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -1,6 +1,23 @@
 # Utility role for bootstrapping future roles
 # Linux runs as root
----
+--- 
+- name: ensure src dir exists
+  file:
+    path: /usr/local/src
+    state: directory
+    mode: 0755
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+  become: yes
+
+- name: ensure shell profile exists
+  file:
+    path: "/Users/{{ ansible_user_id }}/.profile"
+    state: touch
+    mode: 0755
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+
 - include_tasks: linux.yml
   when: ansible_system == "Linux"
 

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -18,5 +18,5 @@
 
 - name: Alias hub to git
   lineinfile:
-    dest: ~/.zshrc
+    dest: ~/.profile
     line: 'eval "$(hub alias -s)"'

--- a/roles/misc/tasks/darwin.yml
+++ b/roles/misc/tasks/darwin.yml
@@ -16,8 +16,3 @@
 
 - name: install teams
   shell: brew cask install microsoft-teams
-
-- name: install sshuttle
-  homebrew:
-    name: sshuttle
-    state: latest

--- a/roles/vim/tasks/main.yml
+++ b/roles/vim/tasks/main.yml
@@ -2,13 +2,15 @@
 - include_tasks: linux.yml
   when: ansible_system == "Linux"
 
-- include_tasks: darwin.yml
-  when: ansible_system == "Darwin"
+# brew install vim hangs, removed
+#- include_tasks: darwin.yml
+#  when: ansible_system == "Darwin"
 
 - name: clone pathogen to ~/.vim
   git:
     repo: 'https://github.com/tpope/vim-pathogen.git'
     dest: ~/.vim/
+    force: yes
 
 - name: create ~/.vim directory
   file:

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include_tasks: linux.yml
+- include_tasks: linux.yml                                       
   when: ansible_system == "Linux"
 
 - include_tasks: darwin.yml
-  when: ansible_system == "Darwin"
+  when: ansible_system == "Darwin" 
 
 - name: Clone oh-my-zsh
   git:
@@ -42,7 +42,7 @@
   become: true
 
 - name: Install powerline
-  shell: pip install powerline-status
+  shell: pip install --user git+git://github.com/powerline/powerline 
   become: true
 
 - name: reload zshrc
@@ -54,7 +54,7 @@
 - name: reload zshrc
   shell: "source ~/.zshrc"
   args:
-    executable: /usr/local/bin/zsh
+    executable: /bin/zsh
   when: ansible_system == "Darwin"
 
 - name: reload shell


### PR DESCRIPTION
I've made changes to `roles/bootstrap`, `roles/zsh`, and `roles/git` to better work with Mac OS 10.14.x.

Also removed the `brew install vim` and `shuttle` as it was causing my latest MacBook to hang... will investigate later.

Tested on a single MacBook Pro 2017... YMMV 